### PR TITLE
add handler wrappers and interfaces

### DIFF
--- a/src/main/java/io/github/cottonmc/energy/api/EnergyConsumerProvider.java
+++ b/src/main/java/io/github/cottonmc/energy/api/EnergyConsumerProvider.java
@@ -1,0 +1,24 @@
+package io.github.cottonmc.energy.api;
+
+import net.minecraft.util.math.Direction;
+
+/**
+ * This interface allows a device to expose its energy consumer/s to other blocks.
+ * Used in place of a Capability.
+ */
+public interface EnergyConsumerProvider {
+
+	/**
+	 * Use this in place of Forge's getCapability.
+	 * @param inspectingFrom the direction your object is being inspected from, to avoid scanning in the wrong direction.
+	 * @return the EnergyConsumer for the specific side.
+	 */
+	EnergyConsumer getEnergyConsumer(Direction inspectingFrom);
+
+	/**
+	 * Use this in place of Forge's hasCapability.
+	 * @param inspectingFrom the dirtection being tested for connectability.
+	 * @return whether the object can be connected to from this direction.
+	 */
+	boolean canConnectToSide(Direction inspectingFrom);
+}

--- a/src/main/java/io/github/cottonmc/energy/api/EnergyProducer.java
+++ b/src/main/java/io/github/cottonmc/energy/api/EnergyProducer.java
@@ -4,7 +4,7 @@ import io.github.cottonmc.energy.util.ContainerInteraction;
 import io.github.cottonmc.energy.util.PacketTier;
 import net.minecraft.util.math.Direction;
 
-public interface EnergyExtractor {
+public interface EnergyProducer {
     /**
      * Attempt to extract an energy packet on an all-or-nothing basis.
      *

--- a/src/main/java/io/github/cottonmc/energy/api/EnergyProducerProvider.java
+++ b/src/main/java/io/github/cottonmc/energy/api/EnergyProducerProvider.java
@@ -1,0 +1,25 @@
+package io.github.cottonmc.energy.api;
+
+import net.minecraft.util.math.Direction;
+
+/**
+ * This interface allows a device to expose its energy producer/s to other blocks.
+ * Used in place of a Capability.
+ */
+public interface EnergyProducerProvider {
+
+	/**
+	 * Use this in place of Forge's getCapability.
+	 * @param inspectingFrom the direction your object is being inspected from, to avoid scanning in the wrong direction.
+	 * @return the EnergyProducer for the specific side.
+	 */
+	EnergyProducer getEnergyProducer(Direction inspectingFrom);
+
+	/**
+	 * Use this in place of Forge's hasCapability.
+	 * @param inspectingFrom the dirtection being tested for connectability.
+	 * @return whether the object can be connected to from this direction.
+	 */
+	boolean canConnectToSide(Direction inspectingFrom);
+}
+

--- a/src/main/java/io/github/cottonmc/energy/api/EnergyStorageProvider.java
+++ b/src/main/java/io/github/cottonmc/energy/api/EnergyStorageProvider.java
@@ -1,0 +1,24 @@
+package io.github.cottonmc.energy.api;
+
+import net.minecraft.util.math.Direction;
+
+/**
+ * This interface allows a device to expose its energy storage/s to other blocks.
+ * Used in place of a Capability.
+ */
+public interface EnergyStorageProvider {
+
+	/**
+	 * Use this in place of Forge's getCapability.
+	 * @param inspectingFrom the direction your object is being inspected from, to avoid scanning in the wrong direction.
+	 * @return the EnergyStorage for the specific side.
+	 */
+	EnergyStorage getEnergyStorage(Direction inspectingFrom);
+
+	/**
+	 * Use this in place of Forge's hasCapability.
+	 * @param inspectingFrom the dirtection being tested for connectability.
+	 * @return whether the object can be connected to from this direction.
+	 */
+	boolean canConnectToSide(Direction inspectingFrom);
+}

--- a/src/main/java/io/github/cottonmc/energy/impl/EnergyConsumerHandler.java
+++ b/src/main/java/io/github/cottonmc/energy/impl/EnergyConsumerHandler.java
@@ -1,0 +1,19 @@
+package io.github.cottonmc.energy.impl;
+
+import io.github.cottonmc.energy.api.EnergyConsumer;
+import io.github.cottonmc.energy.util.PacketTier;
+import net.minecraft.util.math.Direction;
+
+public class EnergyConsumerHandler implements EnergyConsumer {
+
+	
+	@Override
+	public boolean canInsertEnergy(Direction insertingFrom, PacketTier size) {
+		return false;
+	}
+
+	@Override
+	public void insertPacket(Direction insertingFrom, PacketTier packetSize) {
+
+	}
+}

--- a/src/main/java/io/github/cottonmc/energy/impl/EnergyProducerHandler.java
+++ b/src/main/java/io/github/cottonmc/energy/impl/EnergyProducerHandler.java
@@ -1,0 +1,18 @@
+package io.github.cottonmc.energy.impl;
+
+import io.github.cottonmc.energy.api.EnergyProducer;
+import io.github.cottonmc.energy.util.PacketTier;
+import net.minecraft.util.math.Direction;
+
+public class EnergyProducerHandler implements EnergyProducer {
+
+	@Override
+	public void extractPacket(Direction extractingFrom, PacketTier packetSize) {
+
+	}
+
+	@Override
+	public boolean canExtractEnergy(Direction extractingFrom, PacketTier size) {
+		return false;
+	}
+}

--- a/src/main/java/io/github/cottonmc/energy/impl/EnergyStorageHandler.java
+++ b/src/main/java/io/github/cottonmc/energy/impl/EnergyStorageHandler.java
@@ -1,0 +1,30 @@
+package io.github.cottonmc.energy.impl;
+
+import io.github.cottonmc.energy.api.EnergyStorage;
+import io.github.cottonmc.energy.util.PacketTier;
+
+public class EnergyStorageHandler implements EnergyStorage {
+	private int currentEnergy;
+	private int maxEnergy;
+	private PacketTier maxPacket;
+
+	public EnergyStorageHandler(int maxEnergy, PacketTier maxPacketSize) {
+		this.maxEnergy = maxEnergy;
+		this.maxPacket = maxPacketSize;
+	}
+
+	@Override
+	public int getMaxCapacity() {
+		return maxEnergy;
+	}
+
+	@Override
+	public int getCurrentEnergy() {
+		return currentEnergy;
+	}
+
+	@Override
+	public PacketTier getPacketTier() {
+		return maxPacket;
+	}
+}

--- a/src/main/java/io/github/cottonmc/energy/util/PacketTier.java
+++ b/src/main/java/io/github/cottonmc/energy/util/PacketTier.java
@@ -23,4 +23,5 @@ public class PacketTier {
     public int getPacketSize() {
         return size;
     }
+
 }


### PR DESCRIPTION
This wraps EnergyStorage, EnergyConsumer, and EnergyProducer so that they can be used without having to implement their logic on the BlockEntity.
TODO: add serializers for each, see if EnergyConsumerHandler and EnergyProducerHandler need to link to EnergyStorageHandler