### PR TITLE
Change LBA dependency to just the core module rather than everything.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -27,8 +27,8 @@ repositories {
 }
 
 dependencies {
-	modCompile ("alexiil.mc.lib:libblockattributes:0.4.2") { transitive = false }
-	include ("alexiil.mc.lib:libblockattributes:0.4.2") { transitive = false }
+	modCompile "alexiil.mc.lib:libblockattributes-core:0.4.7"
+	include "alexiil.mc.lib:libblockattributes-core:0.4.7"
 
 	implementation "com.google.code.findbugs:jsr305:3.0.2"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
     ]
   },
   "requires": {
-    "libblockattributes": ">=0.3.0"
+    "libblockattributes-core": ">=0.4.7"
   },
   "custom": {
     "modmenu:api": true


### PR DESCRIPTION
Changes proposed in this pull request:
  - Update LBA from 0.4.2 to 0.4.7 (the latest at this current time)
  - Only depend on lba-core rather than everything (which shrinks the resultant jar from 200kB to 60kB)
  - Change transitive deps back to the default (true) because LBA now publishes a POM without the fabric dependencies as of https://github.com/AlexIIL/LibBlockAttributes/commit/2936fc3faaa0fa0cc38d5c7848090ce7f34be1a2 and https://github.com/AlexIIL/LibBlockAttributes/commit/679bb96840a56549a8d70026c249cbf3e5579629 (POM: https://mod-buildcraft.com/maven/alexiil/mc/lib/libblockattributes-core/0.4.7/libblockattributes-core-0.4.7.pom)

This will help fix the crash mentioned at the bottom of https://github.com/StellarHorizons/Galacticraft-Rewoven/commit/13f93fa7ff9723c7c8beb2b3478a7ba236d46cfd .